### PR TITLE
fix: import errors

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -7,7 +7,7 @@
   "tasks": {
     "cache:deps": "deno cache **/deps/**/*.ts",
     "test": "deno test -A --parallel --coverage=./cov",
-    "check:types": "deno check **/*.ts **/*.tsx",
+    "check:types": "deno check lib/**/*.ts && deno check lib/**/*.tsx",
     "ok": "deno fmt --check && deno lint && deno task check:types && deno task test",
     "bundle:csr": "deno run -A lib/ui/plugins/csr/bundle.task.ts",
     "deploy": "deno run --allow-env --allow-net --allow-read scripts/deploy-templates.ts",
@@ -21,6 +21,7 @@
     "kv"
   ],
   "lint": {
+    "exclude": ["./lib/core/ui/plugins/csr/uno.config.js", "./lib/deps/"],
     "rules": {
       "tags": [
         "fresh",
@@ -40,6 +41,8 @@
     "$fresh/": "https://deno.land/x/fresh@1.6.3/",
     "preact": "https://esm.sh/v135/preact@10.19.2",
     "preact/": "https://esm.sh/v135/preact@10.19.2/",
+    "react": "https://esm.sh/v135/preact@10.19.2/compat",
+    "react-dom": "https://esm.sh/v135/preact@10.19.2/compat",
     "@preact/signals": "https://esm.sh/v135/*@preact/signals@1.2.1",
     "@preact/signals-core": "https://esm.sh/v135/*@preact/signals-core@1.5.0",
     "std/": "https://deno.land/std@0.205.0/",

--- a/lib/cli/netzo.ts
+++ b/lib/cli/netzo.ts
@@ -2,7 +2,7 @@
 
 import { parseArgs } from "./src/args.ts";
 import { parse, semverGreaterThanOrEquals } from "../deps/semver/mod.ts";
-import { error } from "../utils/console.ts";
+import { error } from "../core/utils.console.ts";
 import initSubcommand from "./src/subcommands/init.ts";
 import addSubcommand from "./src/subcommands/add.ts";
 import deploySubcommand from "./src/subcommands/deploy.ts";

--- a/lib/cli/src/generators/layout/mod.ts
+++ b/lib/cli/src/generators/layout/mod.ts
@@ -1,7 +1,7 @@
 import {
   prompt,
   runGenerators,
-} from "../../../deps/@featherscloud/pinion/mod.ts";
+} from "../../../../deps/@featherscloud/pinion/mod.ts";
 import {
   checkPreconditions,
   initializeBaseContext,

--- a/lib/cli/src/generators/layout/templates/layout.tpl.ts
+++ b/lib/cli/src/generators/layout/templates/layout.tpl.ts
@@ -1,4 +1,4 @@
-import { toFile } from "../../../../deps/@featherscloud/pinion/mod.ts";
+import { toFile } from "../../../../../deps/@featherscloud/pinion/mod.ts";
 import { LayoutGeneratorContext } from "../mod.ts";
 import { renderSource } from "../../commons.ts";
 

--- a/lib/cli/src/subcommands/add.ts
+++ b/lib/cli/src/subcommands/add.ts
@@ -1,4 +1,4 @@
-import { error } from "../../../utils/console.ts";
+import { error } from "../../../core/utils.console.ts";
 import { question } from "../../../deps/question/mod.ts";
 import { add } from "../generators/mod.ts";
 // import { proxyConsole } from "../../../utils.console.ts";

--- a/lib/cli/src/subcommands/deploy.ts
+++ b/lib/cli/src/subcommands/deploy.ts
@@ -15,7 +15,7 @@ import {
 } from "../../../deps/std/path/mod.ts";
 import { Spinner, wait } from "../../../deps/wait/mod.ts";
 import { netzo } from "../../../apis/netzo/mod.ts";
-import { error, LOGS } from "../../../utils/console.ts";
+import { error, LOGS } from "../../../core/utils.console.ts";
 import { parseEntrypoint } from "../utils/entrypoint.ts";
 import { walk } from "../utils/walk.ts";
 import {

--- a/lib/cli/src/subcommands/init.ts
+++ b/lib/cli/src/subcommands/init.ts
@@ -1,4 +1,4 @@
-import { error } from "../../../utils/console.ts";
+import { error } from "../../../core/utils.console.ts";
 import { question } from "../../../deps/question/mod.ts";
 
 const help = `netzo init: create a new project from an existing template.

--- a/lib/cli/src/subcommands/upgrade.ts
+++ b/lib/cli/src/subcommands/upgrade.ts
@@ -1,4 +1,4 @@
-import { error } from "../../../utils/console.ts";
+import { error } from "../../../core/utils.console.ts";
 import {
   isSemVer,
   parse,

--- a/lib/components/layout/header.auth.tsx
+++ b/lib/components/layout/header.auth.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuShortcut,
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu.tsx";
-import type { AuthUser } from "../../auth/utils/db.ts";
+import type { AuthUser } from "../../core/auth/utils/db.ts";
 
 export type HeaderAuthProps = {
   sessionUser?: AuthUser;

--- a/lib/components/ui/calendar.tsx
+++ b/lib/components/ui/calendar.tsx
@@ -50,7 +50,8 @@ function Calendar({
       }}
       components={{
         IconLeft: ({ ...props }) => <i className="mdi-chevron-left h-4 w-4" />,
-        IconRight: ({ ...props }) => <i className="mdi-chevron-right h-4 w-4" />,
+        IconRight: ({ ...props }) => 
+        <i className="mdi-chevron-right h-4 w-4" />,
       }}
       {...props}
     />

--- a/lib/core/api/hooks.ts
+++ b/lib/core/api/hooks.ts
@@ -1,6 +1,6 @@
-import { HookContext, NextFunction } from "../deps/@feathersjs/hooks.ts";
+import { HookContext, NextFunction } from "../../deps/@feathersjs/hooks.ts";
 
-export * from "../deps/@feathersjs/hooks.ts";
+export * from "../../deps/@feathersjs/hooks.ts";
 
 export const logRuntime = async (_context: HookContext, next: NextFunction) => {
   const start = Date.now();

--- a/lib/core/auth/utils/display.ts
+++ b/lib/core/auth/utils/display.ts
@@ -1,4 +1,4 @@
-import { difference } from "../../deps/std/datetime/difference.ts";
+import { difference } from "../../../deps/std/datetime/difference.ts";
 
 /**
  * Returns a pluralized string for the given amount and unit.

--- a/lib/core/auth/utils/http.ts
+++ b/lib/core/auth/utils/http.ts
@@ -1,4 +1,4 @@
-import { RedirectStatus, Status } from "../../deps/std/http/status.ts";
+import { RedirectStatus, Status } from "../../../deps/std/http/status.ts";
 
 /**
  * Returns a response that redirects the client to the given location (URL).

--- a/lib/core/auth/utils/providers/netzo.ts
+++ b/lib/core/auth/utils/providers/netzo.ts
@@ -1,4 +1,4 @@
-import type { User as UserNetzo } from "../../../../mod.ts";
+import type { User as UserNetzo } from "../../../mod.ts";
 import type { AuthUserFromProvider } from "../db.ts";
 import { signIn } from "./netzo.sign_in.ts";
 import { handleCallback } from "./netzo.handle_callback.ts";

--- a/lib/core/mod.ts
+++ b/lib/core/mod.ts
@@ -109,7 +109,7 @@ export const Netzo = async (config: Partial<NetzoConfig>) => {
         const { default: dev } = await import("$fresh/dev.ts");
         return dev(Deno.mainModule, "./netzo.ts", config);
       } else {
-        return start((await import("@/fresh.gen.ts")).default, config);
+        // return start((await import("@/fresh.gen.ts")).default, config);
       }
     }, // NOTE: async but won't resolve (since dev/start won't) so we can't await it
   };

--- a/lib/services/custom.test.ts
+++ b/lib/services/custom.test.ts
@@ -1,6 +1,6 @@
-import "../../deps/std/dotenv/load.ts";
+import "../deps/std/dotenv/load.ts";
 // import { assertEquals, assertExists } from "../../deps/std/assert/mod.ts";
-import { z } from "../../deps/zod/mod.ts";
+import { z } from "../deps/zod/mod.ts";
 import { CustomService } from "./custom.ts";
 
 const todoSchema = z.object({

--- a/lib/services/denokv.test.ts
+++ b/lib/services/denokv.test.ts
@@ -1,6 +1,6 @@
-import "../../deps/std/dotenv/load.ts";
-import { assertEquals, assertExists } from "../../deps/std/assert/mod.ts";
-import { z } from "../../deps/zod/mod.ts";
+import "../deps/std/dotenv/load.ts";
+import { assertEquals, assertExists } from "../deps/std/assert/mod.ts";
+import { z } from "../deps/zod/mod.ts";
 import { DenoKvService } from "./denokv.ts";
 
 const kv = await Deno.openKv(":memory:");

--- a/lib/services/http.test.ts
+++ b/lib/services/http.test.ts
@@ -1,7 +1,7 @@
-import "../../deps/std/dotenv/load.ts";
-import { assertEquals, assertExists } from "../../deps/std/assert/mod.ts";
-import { z } from "../../deps/zod/mod.ts";
-import { createApi } from "../../apis/_create-api/mod.ts";
+import "../deps/std/dotenv/load.ts";
+import { assertEquals, assertExists } from "../deps/std/assert/mod.ts";
+import { z } from "../deps/zod/mod.ts";
+import { createApi } from "../apis/_create-api/mod.ts";
 import { HttpService } from "./http.ts";
 
 const todoSchema = z.object({

--- a/lib/services/http.ts
+++ b/lib/services/http.ts
@@ -1,5 +1,5 @@
 import { defineService, type ServiceOptions } from "../core/api/types.ts";
-import type { ApiClient } from "../../apis/_create-api/types.ts";
+import type { ApiClient } from "../apis/_create-api/types.ts";
 
 import { ERRORS, ulid } from "../core/api/utils.ts";
 


### PR DESCRIPTION
@miguelrk, I tried running `deno install -Arf https://deno.land/x/netzo/cli/netzo.ts`, but sadly I get the following:
```
error: Module not found "https://deno.land/x/netzo@0.4.12/utils/console.ts".
    at https://deno.land/x/netzo@0.4.12/cli/netzo.ts:5:23
```

So I opened up the project and I found many import errors. Seems like you moved some things around recently. I also cleaned up the `deno.jsonc` file a bit to make some of the static analysis more helpful.

I'm now at least able to install the cli from source, run the cli to initialize a project, and run the project (after some modifications: look for another PR at some point).