### PR TITLE
chore: improve remote cli test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,15 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
+      - name: Get Latest Release
+        id: latest_release
+        uses: pozetroninc/github-action-get-latest-release@v0.7.0
+        with:
+          repository: 'netzo/netzo'
+
+      - name: Set Latest Release as Env Variable
+        run: echo "LATEST_RELEASE=${{ steps.latest_release.outputs.release }}" >> $GITHUB_ENV
+
       - name: Git Checkout
         uses: actions/checkout@v4
 

--- a/lib/cli/tests/init.test.ts
+++ b/lib/cli/tests/init.test.ts
@@ -117,7 +117,7 @@ Deno.test("remote CLI execution", async (t) => {
   await t.step("init project from current commit and verify", async () => {
     const currentCommitUrl =
       `https://raw.githubusercontent.com/${githubRepository}/${commitSHA}/lib/cli/netzo.ts`;
-    console.log({ currentCommitUrl });
+
     await executeAndAssert(
       $`deno run -A ${currentCommitUrl} init minimal --dir ${tmpDirName}`,
     );
@@ -137,7 +137,7 @@ Deno.test("remote CLI execution", async (t) => {
   await t.step("init project from latest release and verify", async () => {
     const latestReleaseUrl =
       `https://deno.land/x/netzo@${latestRelease}/cli/netzo.ts`;
-    console.log({ latestReleaseUrl });
+
     await executeAndAssert(
       $`deno run -A ${latestReleaseUrl} init minimal --dir ${tmpDirNameForRelease}`,
     );

--- a/lib/cli/tests/init.test.ts
+++ b/lib/cli/tests/init.test.ts
@@ -103,23 +103,53 @@ Deno.test("CLI init reflects changes in the template -- minimal", async () => {
 });
 
 Deno.test("remote CLI execution", async (t) => {
+  const commitSHA = Deno.env.get("GITHUB_SHA"); // always provided by github
+  const githubRepository = Deno.env.get("GITHUB_REPOSITORY"); // always provided by github
+  const latestRelease = Deno.env.get("LATEST_RELEASE"); // set via pozetroninc/github-action-get-latest-release
+
+  if (!commitSHA || !latestRelease || !githubRepository) {
+    console.log("Environment variables not set. Exiting test.");
+    return;
+  }
+
   const tmpDirName = await Deno.makeTempDir();
 
-  await t.step("init project", async () => {
+  await t.step("init project from current commit and verify", async () => {
+    const currentCommitUrl =
+      `https://raw.githubusercontent.com/${githubRepository}/${commitSHA}/lib/cli/netzo.ts`;
+    console.log({ currentCommitUrl });
     await executeAndAssert(
-      $`deno run -A https://raw.githubusercontent.com/deer/netzo/improve_denojson_generation/lib/cli/netzo.ts init minimal --dir ${tmpDirName}`,
+      $`deno run -A ${currentCommitUrl} init minimal --dir ${tmpDirName}`,
     );
-  });
 
-  await t.step("check netzo location", () => {
     assertStringIncludes(
       netzoLocation(tmpDirName),
-      "https://raw.githubusercontent.com/deer/netzo/improve_denojson_generation",
+      `https://raw.githubusercontent.com/${githubRepository}/${commitSHA}/`,
     );
   });
 
-  await t.step("cleanup", async () => {
+  await t.step("cleanup after current commit test", async () => {
     await retry(() => Deno.remove(tmpDirName, { recursive: true }));
+  });
+
+  const tmpDirNameForRelease = await Deno.makeTempDir();
+
+  await t.step("init project from latest release and verify", async () => {
+    const latestReleaseUrl =
+      `https://deno.land/x/netzo@${latestRelease}/cli/netzo.ts`;
+    console.log({ latestReleaseUrl });
+    await executeAndAssert(
+      $`deno run -A ${latestReleaseUrl} init minimal --dir ${tmpDirNameForRelease}`,
+    );
+
+    assertStringIncludes(
+      netzoLocation(tmpDirNameForRelease),
+      `https://deno.land/x/netzo@${latestRelease}/`,
+    );
+  });
+
+  await t.step("cleanup after latest release test", async () => {
+    await retry(() => Deno.remove(tmpDirNameForRelease, { recursive: true }));
   });
 });
 

--- a/templates/crm/deno.json
+++ b/templates/crm/deno.json
@@ -41,7 +41,7 @@
   },
   "imports": {
     "@/": "./",
-    "netzo/": "https://deno.land/x/netzo@0.4.33/",
+    "netzo/": "../../lib/",
     "$fresh/": "https://deno.land/x/fresh@1.6.3/",
     "preact": "https://esm.sh/v135/preact@10.19.3",
     "preact/": "https://esm.sh/v135/preact@10.19.3/",

--- a/templates/minimal/deno.json
+++ b/templates/minimal/deno.json
@@ -23,7 +23,7 @@
   },
   "imports": {
     "@/": "./",
-    "netzo/": "https://deno.land/x/netzo@0.4.33/",
+    "netzo/": "../../lib/",
     "$fresh/": "https://deno.land/x/fresh@1.6.3/",
     "preact": "https://esm.sh/v135/preact@10.19.3",
     "preact/": "https://esm.sh/v135/preact@10.19.3/",


### PR DESCRIPTION
closes https://github.com/netzo/netzo/issues/102

Before the logs from the first run go away, here's what they outputted:
```
{ currentCommitUrl: "https://raw.githubusercontent.com/netzo/netzo/40148e3800459eb585253c3ad107a7b8d5bdd2ba/lib/cli/netzo.ts" }
{ latestReleaseUrl: "https://deno.land/x/netzo@0.4.33/cli/netzo.ts" }
```
Note:
> When a workflow is triggered by a pull request event (pull_request), GitHub Actions checks out the merge commit that GitHub automatically creates for the PR. This merge commit is a combination of the latest commits from the base branch (usually main or master) and the head branch of the PR. Therefore, GITHUB_SHA in this context refers to the hash of this merge commit, not the latest commit on the PR's branch.

So this is why the commit mentioned doesn't match what you see below:
```
chore: improve remote cli test          637b927
```

The other thing to note here is that now that `init` takes care of properly updating the netzo path (as this test and the others very thoroughly verify for all cases), we can switch the templates to always using relative paths.