### PR TITLE
chore: cleanup some linting errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,11 @@ jobs:
       - name: Format
         run: deno fmt --check
 
+      - name: Lint
+        run: deno lint --rules-exclude=no-explicit-any
+
       - name: Test
         run: deno test -A lib/cli/tests/
-
-      # - name: Lint
-      #   run: deno lint
 
       # - name: Tests
       #   run: deno test --allow-env --allow-net --allow-read --allow-run

--- a/lib/cli/src/generators/mod.ts
+++ b/lib/cli/src/generators/mod.ts
@@ -4,7 +4,7 @@ import { existsSync } from "../../../deps/std/fs/exists.ts";
 import { getContext /* loadModule */ } from "../../../deps/@featherscloud/pinion/mod.ts";
 
 export const add = async (cmd: string[]) => {
-  const [generatorFile, resource, name, ...argv] = cmd;
+  const [generatorFile, resource, _name, ...argv] = cmd;
 
   if (!generatorFile) {
     throw new Error("Please specify a generator file name");

--- a/lib/components/blocks/form/types.ts
+++ b/lib/components/blocks/form/types.ts
@@ -1,4 +1,4 @@
-import type { ComponentChildren, JSX } from "../../../deps/preact.ts";
+import type { FunctionalComponent, JSX } from "../../../deps/preact.ts";
 import {
   ControllerRenderProps,
   FieldValues,

--- a/lib/components/blocks/table/use-table.ts
+++ b/lib/components/blocks/table/use-table.ts
@@ -37,9 +37,9 @@ export type TableProps<TData = unknown, TValue = unknown> = {
       options: { label: string; value: string }[];
     }[];
     layouts: {
-      grid?: {};
-      gallery?: {};
-      kanban?: {};
+      grid?: Record<string | number | symbol, never>;
+      gallery?: Record<string | number | symbol, never>;
+      kanban?: Record<string | number | symbol, never>;
     };
   };
   columns: ColumnDef<TData, TValue>[];
@@ -49,7 +49,6 @@ export type { Table };
 
 export const useTable = <TData = unknown, TValue = unknown>({
   data,
-  options,
   columns,
   meta = {},
 }: TableProps<TData, TValue>): Table<TData> => {

--- a/lib/components/command.tsx
+++ b/lib/components/command.tsx
@@ -5,7 +5,6 @@ import {
   type ComponentProps,
   forwardRef,
   type Ref,
-  useState,
 } from "../deps/preact/compat.ts";
 import { cn } from "./utils.ts";
 import { Dialog, DialogContent } from "./dialog.tsx";
@@ -25,7 +24,7 @@ const Command = forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/lib/components/input.tsx
+++ b/lib/components/input.tsx
@@ -1,13 +1,8 @@
 import type { JSX } from "../deps/preact.ts";
-import {
-  type ComponentProps,
-  forwardRef,
-  type Ref,
-  useState,
-} from "../deps/preact/compat.ts";
+import { forwardRef } from "../deps/preact/compat.ts";
 import { cn } from "./utils.ts";
 
-export interface InputProps extends JSX.HTMLAttributes<HTMLInputElement> {}
+export type InputProps = JSX.HTMLAttributes<HTMLInputElement>;
 
 const Input = forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {

--- a/lib/components/textarea.tsx
+++ b/lib/components/textarea.tsx
@@ -1,14 +1,8 @@
 import type { JSX } from "../deps/preact.ts";
-import {
-  type ComponentProps,
-  forwardRef,
-  type Ref,
-  useState,
-} from "../deps/preact/compat.ts";
+import { forwardRef } from "../deps/preact/compat.ts";
 import { cn } from "./utils.ts";
 
-export interface TextareaProps
-  extends JSX.HTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = JSX.HTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/lib/hooks/use-dark-mode.ts
+++ b/lib/hooks/use-dark-mode.ts
@@ -16,7 +16,7 @@ function getDarkMode(): boolean {
     const localStorageTheme: "true" | "false" = localStorage.getItem(
       "netzo:darkMode",
     );
-    const systemSettingDark = window.matchMedia(
+    const systemSettingDark = globalThis.matchMedia(
       "(prefers-color-scheme: dark)",
     );
     if (localStorageTheme !== null) return localStorageTheme === "true";

--- a/lib/plugins/api/plugin.ts
+++ b/lib/plugins/api/plugin.ts
@@ -52,14 +52,13 @@ export const api = (options?: ApiConfig): Plugin => {
         handler: {
           GET: resource?.find
             ? async (_req, ctx) => {
-              const { params, query } = parseSearchParams(ctx.url.searchParams);
+              const { query } = parseSearchParams(ctx.url.searchParams);
               const result = await resource.find(query);
               return Response.json(result);
             }
             : () => RESPONSES.notAllowed(),
           POST: resource?.create
-            ? async (req, ctx) => {
-              const { params } = parseSearchParams(ctx.url.searchParams);
+            ? async (req, _ctx) => {
               const data = await parseRequestBody(req);
               const result = await resource.create(data, idField);
               return Response.json(result);
@@ -72,14 +71,12 @@ export const api = (options?: ApiConfig): Plugin => {
         handler: {
           GET: resource?.get
             ? async (_req, ctx) => {
-              const { params, query } = parseSearchParams(ctx.url.searchParams);
               const result = await resource.get(ctx.params.id);
               return Response.json(result);
             }
             : () => RESPONSES.notAllowed(),
           PUT: resource?.update
             ? async (req, ctx) => {
-              const { params } = parseSearchParams(ctx.url.searchParams);
               const data = await parseRequestBody(req);
               const result = await resource.update(ctx.params.id, data);
               return Response.json(result);
@@ -87,7 +84,6 @@ export const api = (options?: ApiConfig): Plugin => {
             : () => RESPONSES.notAllowed(),
           PATCH: resource?.patch
             ? async (req, ctx) => {
-              const { params } = parseSearchParams(ctx.url.searchParams);
               const data = await parseRequestBody(req);
               const result = await resource.patch(ctx.params.id, data);
               return Response.json(result);
@@ -95,7 +91,6 @@ export const api = (options?: ApiConfig): Plugin => {
             : () => RESPONSES.notAllowed(),
           DELETE: resource?.remove
             ? async (_req, ctx) => {
-              const { params } = parseSearchParams(ctx.url.searchParams);
               const result = await resource.remove(ctx.params.id);
               return Response.json(result);
             }

--- a/lib/plugins/auth/routes/mod.ts
+++ b/lib/plugins/auth/routes/mod.ts
@@ -20,10 +20,10 @@ export const getRoutesByProvider = (
 ): PluginRoute[] => {
   const [signIn, handleCallback, signOut] = getFunctionsByProvider(provider);
 
-  const routes = [
+  const routes: PluginRoute[] = [
     {
       path: `/auth/${provider}/signin`,
-      handler: async (req, ctx) => {
+      handler: async (req, _ctx) => {
         const authConfig = getAuthConfig(provider, options);
         const response = await signIn(req, authConfig);
         return response;
@@ -31,7 +31,7 @@ export const getRoutesByProvider = (
     },
     {
       path: `/auth/${provider}/callback`,
-      handler: async (req, ctx) => {
+      handler: async (req, _ctx) => {
         const authConfig = getAuthConfig(provider, options);
         const { response, tokens, sessionId } = await handleCallback(
           req,

--- a/lib/plugins/unocss/preset-netzo.ts
+++ b/lib/plugins/unocss/preset-netzo.ts
@@ -44,17 +44,17 @@ export function presetNetzo(
         collections: {
           mdi: () =>
             import("https://esm.sh/v135/@iconify-json/mdi/icons.json", {
-              assert: { type: "json" },
+              with: { type: "json" },
             }).then((i) => i.default),
           logos: () =>
             import("https://esm.sh/v135/@iconify-json/logos/icons.json", {
-              assert: { type: "json" },
+              with: { type: "json" },
             }).then((i) => i.default),
           "simple-icons": () =>
             import(
               "https://esm.sh/v135/@iconify-json/simple-icons/icons.json",
               {
-                assert: { type: "json" },
+                with: { type: "json" },
               }
             ).then((i) => i.default),
           netzo: {

--- a/lib/resources/custom.test.ts
+++ b/lib/resources/custom.test.ts
@@ -1,7 +1,7 @@
 import "../deps/std/dotenv/load.ts";
 // import { assertEquals, assertExists } from "../../deps/std/assert/mod.ts";
 import { z } from "../deps/zod/mod.ts";
-import { CustomResource } from "./custom.ts";
+// import { CustomResource } from "./custom.ts";
 
 const todoSchema = z.object({
   id: z.number(),
@@ -12,8 +12,8 @@ const todoSchema = z.object({
 
 type Todo = z.infer<typeof todoSchema>;
 
-Deno.test("[api/adapters] CustomResource", async (t) => {
-  const $todos = CustomResource({
-    idField: "id",
-  });
-});
+// Deno.test("[api/adapters] CustomResource", async (t) => {
+//   const $todos = CustomResource({
+//     idField: "id",
+//   });
+// });

--- a/lib/resources/custom.ts
+++ b/lib/resources/custom.ts
@@ -1,7 +1,7 @@
 import { defineResource, type ResourceOptions } from "../plugins/api/types.ts";
 import { NotImplemented } from "../plugins/api/errors.ts";
 
-export type CustomResourceOptions = ResourceOptions & {};
+export type CustomResourceOptions = ResourceOptions;
 
 /**
  * Creates a Resource instance to perform RESTful operations on an CUSTOM resource
@@ -16,23 +16,23 @@ export const CustomResource = defineResource<CustomResourceOptions>(
       options: {
         idField,
       },
-      find: (query) => {
+      find: (_query) => {
         throw new NotImplemented();
       },
-      get: (id) => {
+      get: (_id) => {
         throw new NotImplemented();
       },
-      create: (data: T) => {
+      create: (_data: T) => {
         throw new NotImplemented();
       },
-      update: (id, data: T) => {
+      update: (_id, _data: T) => {
         throw new NotImplemented();
       },
-      patch: async (id, data: Partial<T>) => {
-        throw new NotImplemented();
+      patch: (_id, _data: Partial<T>) => {
+        Promise.reject(new NotImplemented());
       },
-      remove: async (id) => {
-        throw new NotImplemented();
+      remove: (_id) => {
+        Promise.reject(new NotImplemented());
       },
     };
   },


### PR DESCRIPTION
towards https://github.com/netzo/netzo/issues/112

When I rerun the analysis mentioned in the issue, we now get:
```
no-explicit-any: 65
```
and
```
{
  "no-explicit-any": {
    files: [
      "./lib/components/blocks/form/fields/array.tsx",
      "./lib/components/blocks/form/fields/enum.tsx",
      "./lib/components/blocks/form/fields/object.tsx",
      "./lib/components/blocks/form/fields/radio-group.tsx",
      "./lib/components/blocks/form/types.ts",
      "./lib/components/blocks/form/utils.ts",
      "./lib/hooks/use-ui.ts",
      "./lib/plugins/api/errors.ts",
      "./lib/plugins/api/utils.ts"
    ],
    count: 65
  }
}
```

I"m not sure if this will break anything, since the testing situation is non-existent 😅 