### PR TITLE
fix(resources): makes `kv` property optional for `DenoKvResource`

### DIFF
--- a/lib/plugins/api/resources/denokv.ts
+++ b/lib/plugins/api/resources/denokv.ts
@@ -1,11 +1,14 @@
 import type { Resource, ResourceOptions } from "./mod.ts";
 import { ERRORS, filterObjectsByKeyValues, ulid } from "../utils.ts";
 
+export const KV = await Deno.openKv();
+
 export type DenoKvResourceOptions = ResourceOptions & {
-  /* The Deno KV store to use (use Deno.openKv(":memory:") for in-memory storage) */
-  kv: Deno.Kv;
   /* The KV prefix location of the resource e.g. ["users"] */
-  prefix?: Deno.KvKey;
+  prefix: Deno.KvKey;
+  /* The Deno KV store to use (defaults to default database via Deno.openKv()).
+  Note that for in-memory storage you can use Deno.openKv(":memory:") */
+  kv?: Deno.Kv;
 };
 
 /**
@@ -16,7 +19,7 @@ export type DenoKvResourceOptions = ResourceOptions & {
 export const DenoKvResource = <T = Record<string, unknown>>(
   options: DenoKvResourceOptions,
 ): Resource<T> => {
-  const { kv = options.kv, prefix, idField = "id" } = options;
+  const { kv = KV, prefix, idField = "id" } = options;
 
   if (!kv) throw new Error(ERRORS.missingProperty("kv"));
   if (!prefix) throw new Error(ERRORS.missingProperty("prefix"));

--- a/lib/plugins/cron/mod.ts
+++ b/lib/plugins/cron/mod.ts
@@ -24,7 +24,7 @@ export type CronParams = Parameters<typeof Deno.cron>;
  * @returns {Proxy} - a proxied Deno.cron object
  */
 export const proxyCron = (kv: Deno.Kv) => {
-  const $runs = DenoKvResource({ kv, prefix: ["$runs"] });
+  const $runs = DenoKvResource({ prefix: ["$runs"], kv });
   return new Proxy(Deno.cron, {
     apply(target, thisArg, argArray: CronParams) {
       const [name, schedule, opt1, opt2] = argArray;

--- a/templates/crm/resources/accounts.ts
+++ b/templates/crm/resources/accounts.ts
@@ -4,12 +4,11 @@ import { defineApiEndpoint } from "netzo/plugins/api/plugin.ts";
 import { DenoKvResource } from "netzo/plugins/api/resources/mod.ts";
 import { authenticate, log } from "netzo/plugins/api/hooks/mod.ts";
 import { ulid } from "netzo/plugins/api/utils.ts";
-import { kv } from "./mod.ts";
 
 export const accounts = defineApiEndpoint({
   name: "accounts",
   idField: "id",
-  resource: DenoKvResource({ kv, prefix: ["accounts"] }),
+  resource: DenoKvResource({ prefix: ["accounts"] }),
   hooks: {
     all: [authenticate(), log()],
     find: [],

--- a/templates/crm/resources/contacts.ts
+++ b/templates/crm/resources/contacts.ts
@@ -4,12 +4,11 @@ import { defineApiEndpoint } from "netzo/plugins/api/plugin.ts";
 import { DenoKvResource } from "netzo/plugins/api/resources/mod.ts";
 import { authenticate, log } from "netzo/plugins/api/hooks/mod.ts";
 import { ulid } from "netzo/plugins/api/utils.ts";
-import { kv } from "./mod.ts";
 
 export const contacts = defineApiEndpoint({
   name: "contacts",
   idField: "id",
-  resource: DenoKvResource({ kv, prefix: ["contacts"] }),
+  resource: DenoKvResource({ prefix: ["contacts"] }),
   hooks: {
     all: [authenticate(), log()],
     find: [],

--- a/templates/crm/resources/deals.ts
+++ b/templates/crm/resources/deals.ts
@@ -4,12 +4,11 @@ import { defineApiEndpoint } from "netzo/plugins/api/plugin.ts";
 import { DenoKvResource } from "netzo/plugins/api/resources/mod.ts";
 import { authenticate, log } from "netzo/plugins/api/hooks/mod.ts";
 import { ulid } from "netzo/plugins/api/utils.ts";
-import { kv } from "./mod.ts";
 
 export const deals = defineApiEndpoint({
   name: "deals",
   idField: "id",
-  resource: DenoKvResource({ kv, prefix: ["deals"] }),
+  resource: DenoKvResource({ prefix: ["deals"] }),
   hooks: {
     all: [authenticate(), log()],
     find: [],

--- a/templates/crm/resources/interactions.ts
+++ b/templates/crm/resources/interactions.ts
@@ -4,12 +4,11 @@ import { defineApiEndpoint } from "netzo/plugins/api/plugin.ts";
 import { DenoKvResource } from "netzo/plugins/api/resources/mod.ts";
 import { authenticate, log } from "netzo/plugins/api/hooks/mod.ts";
 import { ulid } from "netzo/plugins/api/utils.ts";
-import { kv } from "./mod.ts";
 
 export const interactions = defineApiEndpoint({
   name: "interactions",
   idField: "id",
-  resource: DenoKvResource({ kv, prefix: ["interactions"] }),
+  resource: DenoKvResource({ prefix: ["interactions"] }),
   hooks: {
     all: [authenticate(), log()],
     find: [],

--- a/templates/crm/resources/invoices.ts
+++ b/templates/crm/resources/invoices.ts
@@ -4,12 +4,11 @@ import { defineApiEndpoint } from "netzo/plugins/api/plugin.ts";
 import { DenoKvResource } from "netzo/plugins/api/resources/mod.ts";
 import { authenticate, log } from "netzo/plugins/api/hooks/mod.ts";
 import { ulid } from "netzo/plugins/api/utils.ts";
-import { kv } from "./mod.ts";
 
 export const invoices = defineApiEndpoint({
   name: "invoices",
   idField: "id",
-  resource: DenoKvResource({ kv, prefix: ["invoices"] }),
+  resource: DenoKvResource({ prefix: ["invoices"] }),
   hooks: {
     all: [authenticate(), log()],
     find: [],

--- a/templates/crm/resources/mod.ts
+++ b/templates/crm/resources/mod.ts
@@ -1,1 +1,0 @@
-export const kv = await Deno.openKv();

--- a/templates/crm/resources/transactions.ts
+++ b/templates/crm/resources/transactions.ts
@@ -4,12 +4,11 @@ import { defineApiEndpoint } from "netzo/plugins/api/plugin.ts";
 import { DenoKvResource } from "netzo/plugins/api/resources/mod.ts";
 import { authenticate, log } from "netzo/plugins/api/hooks/mod.ts";
 import { ulid } from "netzo/plugins/api/utils.ts";
-import { kv } from "./mod.ts";
 
 export const transactions = defineApiEndpoint({
   name: "transactions",
   idField: "id",
-  resource: DenoKvResource({ kv, prefix: ["transactions"] }),
+  resource: DenoKvResource({ prefix: ["transactions"] }),
   hooks: {
     all: [authenticate(), log()],
     find: [],


### PR DESCRIPTION
Hotfix for #124

Making the `kv` instance a required property for `DenoKvResource` options was causing issues with `Deno` leaking to the browser. After refactoring to try out different project structures, it was hard to avoid leaks, which result in a very poor UX (and DX). Making the `kv` property optional not only fixes these issue altogether, it also avoids having to explicitly instantiate a `kv` instance via `Deno.openKv()` in another file e.g. `db.ts`. Noteworthy is, that in the context of netzo, interacting with `kv` directly is actually not desired, as all interactions should be made via resources and/or the API itself to benefit from resource methods, hooks, resolvers, etc.