### PR TITLE
fix: silence output from git init and commit

### DIFF
--- a/lib/cli/src/subcommands/init.ts
+++ b/lib/cli/src/subcommands/init.ts
@@ -138,8 +138,8 @@ function patchDenoJson(dir: string) {
 }
 
 async function createGit(dir: string) {
-  await $`git -C ${dir} init`;
+  await $`git -C ${dir} init`.quiet("stdout");;
   await $`git -C ${dir} branch -m main`;
   await $`git -C ${dir} add .`;
-  await $`git -C ${dir} commit -m "initial commit"`;
+  await $`git -C ${dir} commit -m "initial commit"`.quiet("stdout");
 }

--- a/lib/cli/src/subcommands/init.ts
+++ b/lib/cli/src/subcommands/init.ts
@@ -138,7 +138,7 @@ function patchDenoJson(dir: string) {
 }
 
 async function createGit(dir: string) {
-  await $`git -C ${dir} init`.quiet("stdout");;
+  await $`git -C ${dir} init`.quiet("stdout");
   await $`git -C ${dir} branch -m main`;
   await $`git -C ${dir} add .`;
   await $`git -C ${dir} commit -m "initial commit"`.quiet("stdout");


### PR DESCRIPTION
Now I get:
```
deno run -A netzo/lib/cli/netzo.ts init minimal
✨ Successfully cloned /Users/reed/code/netzo/netzo/templates/minimal to minimal
```
instead of:
```
deno run -A netzo/lib/cli/netzo.ts init minimal
✨ Successfully cloned /Users/reed/code/netzo/netzo/templates/minimal to minimal
Initialized empty Git repository in /Users/reed/code/netzo/minimal/.git/
[main (root-commit) 50562e2] initial commit
 6 files changed, 109 insertions(+)
 create mode 100644 deno.json
 create mode 100644 fresh.gen.ts
 create mode 100644 netzo.ts
 create mode 100644 routes/index.tsx
 create mode 100644 tests/test.ts
 create mode 100644 tests/test.utils.ts
```