### PR TITLE
refactor(templates): splits the `resources/{name}.ts` file

### DIFF
--- a/templates/crm/data/accounts.ts
+++ b/templates/crm/data/accounts.ts
@@ -1,24 +1,6 @@
 import { z } from "zod";
 import { faker } from "npm:@faker-js/faker@8.4.0";
-import { defineApiEndpoint } from "netzo/plugins/api/plugin.ts";
-import { DenoKvResource } from "netzo/plugins/api/resources/mod.ts";
-import { authenticate, log } from "netzo/plugins/api/hooks/mod.ts";
 import { ulid } from "netzo/plugins/api/utils.ts";
-
-export const accounts = defineApiEndpoint({
-  name: "accounts",
-  idField: "id",
-  resource: DenoKvResource({ prefix: ["accounts"] }),
-  hooks: {
-    all: [authenticate(), log()],
-    find: [],
-    get: [],
-    create: [],
-    update: [],
-    patch: [],
-    remove: [],
-  },
-});
 
 // schemas:
 

--- a/templates/crm/data/contacts.ts
+++ b/templates/crm/data/contacts.ts
@@ -1,24 +1,6 @@
 import { z } from "zod";
 import { faker } from "npm:@faker-js/faker@8.4.0";
-import { defineApiEndpoint } from "netzo/plugins/api/plugin.ts";
-import { DenoKvResource } from "netzo/plugins/api/resources/mod.ts";
-import { authenticate, log } from "netzo/plugins/api/hooks/mod.ts";
 import { ulid } from "netzo/plugins/api/utils.ts";
-
-export const contacts = defineApiEndpoint({
-  name: "contacts",
-  idField: "id",
-  resource: DenoKvResource({ prefix: ["contacts"] }),
-  hooks: {
-    all: [authenticate(), log()],
-    find: [],
-    get: [],
-    create: [],
-    update: [],
-    patch: [],
-    remove: [],
-  },
-});
 
 // schemas:
 

--- a/templates/crm/data/deals.ts
+++ b/templates/crm/data/deals.ts
@@ -1,24 +1,6 @@
 import { z } from "zod";
 import { faker } from "npm:@faker-js/faker@8.4.0";
-import { defineApiEndpoint } from "netzo/plugins/api/plugin.ts";
-import { DenoKvResource } from "netzo/plugins/api/resources/mod.ts";
-import { authenticate, log } from "netzo/plugins/api/hooks/mod.ts";
 import { ulid } from "netzo/plugins/api/utils.ts";
-
-export const deals = defineApiEndpoint({
-  name: "deals",
-  idField: "id",
-  resource: DenoKvResource({ prefix: ["deals"] }),
-  hooks: {
-    all: [authenticate(), log()],
-    find: [],
-    get: [],
-    create: [],
-    update: [],
-    patch: [],
-    remove: [],
-  },
-});
 
 // schemas:
 

--- a/templates/crm/data/interactions.ts
+++ b/templates/crm/data/interactions.ts
@@ -1,24 +1,6 @@
 import { z } from "zod";
 import { faker } from "npm:@faker-js/faker@8.4.0";
-import { defineApiEndpoint } from "netzo/plugins/api/plugin.ts";
-import { DenoKvResource } from "netzo/plugins/api/resources/mod.ts";
-import { authenticate, log } from "netzo/plugins/api/hooks/mod.ts";
 import { ulid } from "netzo/plugins/api/utils.ts";
-
-export const interactions = defineApiEndpoint({
-  name: "interactions",
-  idField: "id",
-  resource: DenoKvResource({ prefix: ["interactions"] }),
-  hooks: {
-    all: [authenticate(), log()],
-    find: [],
-    get: [],
-    create: [],
-    update: [],
-    patch: [],
-    remove: [],
-  },
-});
 
 // schemas:
 

--- a/templates/crm/data/invoices.ts
+++ b/templates/crm/data/invoices.ts
@@ -1,24 +1,6 @@
 import { z } from "zod";
 import { faker } from "npm:@faker-js/faker@8.4.0";
-import { defineApiEndpoint } from "netzo/plugins/api/plugin.ts";
-import { DenoKvResource } from "netzo/plugins/api/resources/mod.ts";
-import { authenticate, log } from "netzo/plugins/api/hooks/mod.ts";
 import { ulid } from "netzo/plugins/api/utils.ts";
-
-export const invoices = defineApiEndpoint({
-  name: "invoices",
-  idField: "id",
-  resource: DenoKvResource({ prefix: ["invoices"] }),
-  hooks: {
-    all: [authenticate(), log()],
-    find: [],
-    get: [],
-    create: [],
-    update: [],
-    patch: [],
-    remove: [],
-  },
-});
 
 // schemas:
 

--- a/templates/crm/data/transactions.ts
+++ b/templates/crm/data/transactions.ts
@@ -1,24 +1,6 @@
 import { z } from "zod";
 import { faker } from "npm:@faker-js/faker@8.4.0";
-import { defineApiEndpoint } from "netzo/plugins/api/plugin.ts";
-import { DenoKvResource } from "netzo/plugins/api/resources/mod.ts";
-import { authenticate, log } from "netzo/plugins/api/hooks/mod.ts";
 import { ulid } from "netzo/plugins/api/utils.ts";
-
-export const transactions = defineApiEndpoint({
-  name: "transactions",
-  idField: "id",
-  resource: DenoKvResource({ prefix: ["transactions"] }),
-  hooks: {
-    all: [authenticate(), log()],
-    find: [],
-    get: [],
-    create: [],
-    update: [],
-    patch: [],
-    remove: [],
-  },
-});
 
 // schemas:
 

--- a/templates/crm/fresh.gen.ts
+++ b/templates/crm/fresh.gen.ts
@@ -8,6 +8,12 @@ import * as $_app from "./routes/_app.tsx";
 import * as $_layout from "./routes/_layout.tsx";
 import * as $accounts_id_ from "./routes/accounts/[id].tsx";
 import * as $accounts_index from "./routes/accounts/index.tsx";
+import * as $api_accounts from "./routes/api/accounts.ts";
+import * as $api_contacts from "./routes/api/contacts.ts";
+import * as $api_deals from "./routes/api/deals.ts";
+import * as $api_interactions from "./routes/api/interactions.ts";
+import * as $api_invoices from "./routes/api/invoices.ts";
+import * as $api_transactions from "./routes/api/transactions.ts";
 import * as $contacts_id_ from "./routes/contacts/[id].tsx";
 import * as $contacts_index from "./routes/contacts/index.tsx";
 import * as $deals_index from "./routes/deals/index.tsx";
@@ -40,6 +46,12 @@ const manifest = {
     "./routes/_layout.tsx": $_layout,
     "./routes/accounts/[id].tsx": $accounts_id_,
     "./routes/accounts/index.tsx": $accounts_index,
+    "./routes/api/accounts.ts": $api_accounts,
+    "./routes/api/contacts.ts": $api_contacts,
+    "./routes/api/deals.ts": $api_deals,
+    "./routes/api/interactions.ts": $api_interactions,
+    "./routes/api/invoices.ts": $api_invoices,
+    "./routes/api/transactions.ts": $api_transactions,
     "./routes/contacts/[id].tsx": $contacts_id_,
     "./routes/contacts/index.tsx": $contacts_index,
     "./routes/deals/index.tsx": $deals_index,

--- a/templates/crm/islands/accounts/Form.tsx
+++ b/templates/crm/islands/accounts/Form.tsx
@@ -1,8 +1,8 @@
 import { useSignal } from "@preact/signals";
 import { Button } from "netzo/components/button.tsx";
 import { createOnSubmit, Form } from "netzo/components/blocks/form/form.tsx";
-import { Account, accountSchema } from "@/resources/accounts.ts";
-// import { I18N } from "@/resources/accounts.ts";
+import { Account, accountSchema } from "@/data/accounts.ts";
+// import { I18N } from "@/data/accounts.ts";
 
 type FormProps = {
   data?: Account;

--- a/templates/crm/islands/accounts/Table.tsx
+++ b/templates/crm/islands/accounts/Table.tsx
@@ -15,7 +15,7 @@ import {
 } from "netzo/components/avatar.tsx";
 import { IconCopy } from "netzo/components/icon-copy.tsx";
 import { Badge } from "netzo/components/badge.tsx";
-import { type Account, accountSchema, I18N } from "@/resources/accounts.ts";
+import { type Account, accountSchema, I18N } from "@/data/accounts.ts";
 
 // NOTE: define columns in island (route to island function serialization unsupported)
 export const getColumns = ({ options }: TableProps): TableProps["columns"] => [

--- a/templates/crm/islands/contacts/Form.tsx
+++ b/templates/crm/islands/contacts/Form.tsx
@@ -1,8 +1,8 @@
 import { useSignal } from "@preact/signals";
 import { Button } from "netzo/components/button.tsx";
 import { createOnSubmit, Form } from "netzo/components/blocks/form/form.tsx";
-import { Contact, contactSchema } from "@/resources/contacts.ts";
-// import { I18N } from "@/resources/contacts.ts";
+import { Contact, contactSchema } from "@/data/contacts.ts";
+// import { I18N } from "@/data/contacts.ts";
 
 type FormProps = {
   data?: Contact;

--- a/templates/crm/islands/contacts/Table.tsx
+++ b/templates/crm/islands/contacts/Table.tsx
@@ -15,7 +15,7 @@ import {
   AvatarImage,
 } from "netzo/components/avatar.tsx";
 import { IconCopy } from "netzo/components/icon-copy.tsx";
-import { type Contact, I18N } from "@/resources/contacts.ts";
+import { type Contact, I18N } from "@/data/contacts.ts";
 
 // NOTE: define columns in island (route to island function serialization unsupported)
 export const getColumns = ({ options }: TableProps): TableProps["columns"] => [

--- a/templates/crm/islands/deals/Kanban.tsx
+++ b/templates/crm/islands/deals/Kanban.tsx
@@ -6,7 +6,7 @@ import {
   Kanban as _Kanban,
   type KanbanProps,
 } from "netzo/components/blocks/kanban/kanban.tsx";
-import { type Deal, I18N } from "@/resources/deals.ts";
+import { type Deal, I18N } from "@/data/deals.ts";
 
 // NOTE: define columns in island (route to island function serialization unsupported)
 export const getColumns = (_props: TableProps): TableProps["columns"] => [];

--- a/templates/crm/islands/interactions/Form.tsx
+++ b/templates/crm/islands/interactions/Form.tsx
@@ -1,8 +1,8 @@
 import { useSignal } from "@preact/signals";
 import { Button } from "netzo/components/button.tsx";
 import { createOnSubmit, Form } from "netzo/components/blocks/form/form.tsx";
-import { Interaction, interactionSchema } from "@/resources/interactions.ts";
-// import { I18N } from "@/resources/interactions.ts";
+import { Interaction, interactionSchema } from "@/data/interactions.ts";
+// import { I18N } from "@/data/interactions.ts";
 
 type FormProps = {
   data?: Interaction;

--- a/templates/crm/islands/interactions/Table.tsx
+++ b/templates/crm/islands/interactions/Table.tsx
@@ -14,7 +14,7 @@ import {
   I18N,
   type Interaction,
   interactionSchema,
-} from "@/resources/interactions.ts";
+} from "@/data/interactions.ts";
 
 // NOTE: define columns in island (route to island function serialization unsupported)
 export const getColumns = (

--- a/templates/crm/islands/invoices/Form.tsx
+++ b/templates/crm/islands/invoices/Form.tsx
@@ -1,8 +1,8 @@
 import { useSignal } from "@preact/signals";
 import { Button } from "netzo/components/button.tsx";
 import { createOnSubmit, Form } from "netzo/components/blocks/form/form.tsx";
-import { Invoice, invoiceSchema } from "@/resources/invoices.ts";
-// import { I18N } from "@/resources/invoices.ts";
+import { Invoice, invoiceSchema } from "@/data/invoices.ts";
+// import { I18N } from "@/data/invoices.ts";
 
 type FormProps = {
   data?: Invoice;

--- a/templates/crm/islands/invoices/Table.tsx
+++ b/templates/crm/islands/invoices/Table.tsx
@@ -10,7 +10,7 @@ import { Grid } from "netzo/components/blocks/table/table.grid.tsx";
 import { toDate, toDateTime } from "netzo/components/blocks/format.ts";
 import { IconCopy } from "netzo/components/icon-copy.tsx";
 import { Badge } from "netzo/components/badge.tsx";
-import { I18N, type Invoice } from "@/resources/invoices.ts";
+import { I18N, type Invoice } from "@/data/invoices.ts";
 
 // NOTE: define columns in island (route to island function serialization unsupported)
 export const getColumns = ({ options }: TableProps): TableProps["columns"] => [

--- a/templates/crm/islands/transactions/Form.tsx
+++ b/templates/crm/islands/transactions/Form.tsx
@@ -1,8 +1,8 @@
 import { useSignal } from "@preact/signals";
 import { Button } from "netzo/components/button.tsx";
 import { createOnSubmit, Form } from "netzo/components/blocks/form/form.tsx";
-import { Transaction, transactionSchema } from "@/resources/transactions.ts";
-// import { I18N } from "@/resources/transactions.ts";
+import { Transaction, transactionSchema } from "@/data/transactions.ts";
+// import { I18N } from "@/data/transactions.ts";
 
 type FormProps = {
   data?: Transaction;

--- a/templates/crm/islands/transactions/Table.tsx
+++ b/templates/crm/islands/transactions/Table.tsx
@@ -14,7 +14,7 @@ import {
   I18N,
   type Transaction,
   transactionSchema,
-} from "@/resources/transactions.ts";
+} from "@/data/transactions.ts";
 import { CellContext } from "netzo/deps/@tanstack/react-table.ts";
 
 // NOTE: define columns in island (route to island function serialization unsupported)

--- a/templates/crm/netzo.ts
+++ b/templates/crm/netzo.ts
@@ -1,10 +1,10 @@
 import { Netzo } from "netzo/mod.ts";
-import { accounts } from "./resources/accounts.ts";
-import { contacts } from "./resources/contacts.ts";
-import { deals } from "./resources/deals.ts";
-import { interactions } from "./resources/interactions.ts";
-import { invoices } from "./resources/invoices.ts";
-import { transactions } from "./resources/transactions.ts";
+import { accounts } from "./routes/api/accounts.ts";
+import { contacts } from "./routes/api/contacts.ts";
+import { deals } from "./routes/api/deals.ts";
+import { interactions } from "./routes/api/interactions.ts";
+import { invoices } from "./routes/api/invoices.ts";
+import { transactions } from "./routes/api/transactions.ts";
 
 export const netzo = await Netzo({
   auth: Deno.env.get("DENO_REGION") ? { providers: { netzo: {} } } : undefined,

--- a/templates/crm/routes/accounts/[id].tsx
+++ b/templates/crm/routes/accounts/[id].tsx
@@ -1,6 +1,6 @@
 import { defineRoute } from "$fresh/server.ts";
 import { Separator } from "netzo/components/separator.tsx";
-import type { Account } from "@/resources/accounts.ts";
+import type { Account } from "@/data/accounts.ts";
 import { FormAccount } from "@/islands/accounts/Form.tsx";
 import { netzo } from "@/netzo.ts";
 

--- a/templates/crm/routes/accounts/index.tsx
+++ b/templates/crm/routes/accounts/index.tsx
@@ -1,6 +1,6 @@
 import { defineRoute } from "$fresh/server.ts";
 import type { TableProps } from "netzo/components/blocks/table/use-table.ts";
-import { type Account, accountSchema, I18N } from "@/resources/accounts.ts";
+import { type Account, accountSchema, I18N } from "@/data/accounts.ts";
 import { Table } from "@/islands/accounts/Table.tsx";
 import { FormAccount } from "@/islands/accounts/Form.tsx";
 import { netzo } from "@/netzo.ts";

--- a/templates/crm/routes/api/accounts.ts
+++ b/templates/crm/routes/api/accounts.ts
@@ -1,0 +1,18 @@
+import { defineApiEndpoint } from "netzo/plugins/api/plugin.ts";
+import { DenoKvResource } from "netzo/plugins/api/resources/mod.ts";
+import { authenticate, log } from "netzo/plugins/api/hooks/mod.ts";
+
+export const accounts = defineApiEndpoint({
+  name: "accounts",
+  idField: "id",
+  resource: DenoKvResource({ prefix: ["accounts"] }),
+  hooks: {
+    all: [authenticate(), log()],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: [],
+  },
+});

--- a/templates/crm/routes/api/contacts.ts
+++ b/templates/crm/routes/api/contacts.ts
@@ -1,0 +1,18 @@
+import { defineApiEndpoint } from "netzo/plugins/api/plugin.ts";
+import { DenoKvResource } from "netzo/plugins/api/resources/mod.ts";
+import { authenticate, log } from "netzo/plugins/api/hooks/mod.ts";
+
+export const contacts = defineApiEndpoint({
+  name: "contacts",
+  idField: "id",
+  resource: DenoKvResource({ prefix: ["contacts"] }),
+  hooks: {
+    all: [authenticate(), log()],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: [],
+  },
+});

--- a/templates/crm/routes/api/deals.ts
+++ b/templates/crm/routes/api/deals.ts
@@ -1,0 +1,18 @@
+import { defineApiEndpoint } from "netzo/plugins/api/plugin.ts";
+import { DenoKvResource } from "netzo/plugins/api/resources/mod.ts";
+import { authenticate, log } from "netzo/plugins/api/hooks/mod.ts";
+
+export const deals = defineApiEndpoint({
+  name: "deals",
+  idField: "id",
+  resource: DenoKvResource({ prefix: ["deals"] }),
+  hooks: {
+    all: [authenticate(), log()],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: [],
+  },
+});

--- a/templates/crm/routes/api/interactions.ts
+++ b/templates/crm/routes/api/interactions.ts
@@ -1,0 +1,18 @@
+import { defineApiEndpoint } from "netzo/plugins/api/plugin.ts";
+import { DenoKvResource } from "netzo/plugins/api/resources/mod.ts";
+import { authenticate, log } from "netzo/plugins/api/hooks/mod.ts";
+
+export const interactions = defineApiEndpoint({
+  name: "interactions",
+  idField: "id",
+  resource: DenoKvResource({ prefix: ["interactions"] }),
+  hooks: {
+    all: [authenticate(), log()],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: [],
+  },
+});

--- a/templates/crm/routes/api/invoices.ts
+++ b/templates/crm/routes/api/invoices.ts
@@ -1,0 +1,18 @@
+import { defineApiEndpoint } from "netzo/plugins/api/plugin.ts";
+import { DenoKvResource } from "netzo/plugins/api/resources/mod.ts";
+import { authenticate, log } from "netzo/plugins/api/hooks/mod.ts";
+
+export const invoices = defineApiEndpoint({
+  name: "invoices",
+  idField: "id",
+  resource: DenoKvResource({ prefix: ["invoices"] }),
+  hooks: {
+    all: [authenticate(), log()],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: [],
+  },
+});

--- a/templates/crm/routes/api/transactions.ts
+++ b/templates/crm/routes/api/transactions.ts
@@ -1,0 +1,18 @@
+import { defineApiEndpoint } from "netzo/plugins/api/plugin.ts";
+import { DenoKvResource } from "netzo/plugins/api/resources/mod.ts";
+import { authenticate, log } from "netzo/plugins/api/hooks/mod.ts";
+
+export const transactions = defineApiEndpoint({
+  name: "transactions",
+  idField: "id",
+  resource: DenoKvResource({ prefix: ["transactions"] }),
+  hooks: {
+    all: [authenticate(), log()],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: [],
+  },
+});

--- a/templates/crm/routes/contacts/[id].tsx
+++ b/templates/crm/routes/contacts/[id].tsx
@@ -1,6 +1,6 @@
 import { defineRoute } from "$fresh/server.ts";
 import { Separator } from "netzo/components/separator.tsx";
-import type { Contact } from "@/resources/contacts.ts";
+import type { Contact } from "@/data/contacts.ts";
 import { FormContact } from "@/islands/contacts/Form.tsx";
 import { netzo } from "@/netzo.ts";
 

--- a/templates/crm/routes/contacts/index.tsx
+++ b/templates/crm/routes/contacts/index.tsx
@@ -1,6 +1,6 @@
 import { defineRoute } from "$fresh/server.ts";
 import type { TableProps } from "netzo/components/blocks/table/use-table.ts";
-import { type Contact, I18N } from "@/resources/contacts.ts";
+import { type Contact, I18N } from "@/data/contacts.ts";
 import { Table } from "@/islands/contacts/Table.tsx";
 import { netzo } from "@/netzo.ts";
 

--- a/templates/crm/routes/deals/index.tsx
+++ b/templates/crm/routes/deals/index.tsx
@@ -1,6 +1,6 @@
 import { defineRoute } from "$fresh/server.ts";
 import type { KanbanProps } from "netzo/components/blocks/kanban/kanban.tsx";
-import { type Deal, I18N } from "@/resources/deals.ts";
+import { type Deal, I18N } from "@/data/deals.ts";
 import { Kanban } from "@/islands/deals/Kanban.tsx";
 import { netzo } from "@/netzo.ts";
 

--- a/templates/crm/routes/index.tsx
+++ b/templates/crm/routes/index.tsx
@@ -1,10 +1,10 @@
 import { defineRoute } from "$fresh/server.ts";
-import type { Account } from "@/resources/accounts.ts";
-import type { Contact } from "@/resources/contacts.ts";
-import type { Deal } from "@/resources/deals.ts";
-import type { Interaction } from "@/resources/interactions.ts";
-import type { Invoice } from "@/resources/invoices.ts";
-import type { Transaction } from "@/resources/transactions.ts";
+import type { Account } from "@/data/accounts.ts";
+import type { Contact } from "@/data/contacts.ts";
+import type { Deal } from "@/data/deals.ts";
+import type { Interaction } from "@/data/interactions.ts";
+import type { Invoice } from "@/data/invoices.ts";
+import type { Transaction } from "@/data/transactions.ts";
 import { Dashboard } from "@/islands/Dashboard.tsx";
 import { netzo } from "@/netzo.ts";
 

--- a/templates/crm/routes/interactions/[id].tsx
+++ b/templates/crm/routes/interactions/[id].tsx
@@ -1,6 +1,6 @@
 import { defineRoute } from "$fresh/server.ts";
 import { Separator } from "netzo/components/separator.tsx";
-import type { Interaction } from "@/resources/interactions.ts";
+import type { Interaction } from "@/data/interactions.ts";
 import { FormInteraction } from "@/islands/interactions/Form.tsx";
 import { netzo } from "@/netzo.ts";
 

--- a/templates/crm/routes/interactions/index.tsx
+++ b/templates/crm/routes/interactions/index.tsx
@@ -4,7 +4,7 @@ import {
   I18N,
   type Interaction,
   interactionSchema,
-} from "@/resources/interactions.ts";
+} from "@/data/interactions.ts";
 import { Table } from "@/islands/interactions/Table.tsx";
 import { FormInteraction } from "@/islands/interactions/Form.tsx";
 import { netzo } from "@/netzo.ts";

--- a/templates/crm/routes/invoices/[id].tsx
+++ b/templates/crm/routes/invoices/[id].tsx
@@ -1,6 +1,6 @@
 import { defineRoute } from "$fresh/server.ts";
 import { Separator } from "netzo/components/separator.tsx";
-import type { Invoice } from "@/resources/invoices.ts";
+import type { Invoice } from "@/data/invoices.ts";
 import { FormInvoice } from "@/islands/invoices/Form.tsx";
 import { netzo } from "@/netzo.ts";
 

--- a/templates/crm/routes/invoices/index.tsx
+++ b/templates/crm/routes/invoices/index.tsx
@@ -1,6 +1,6 @@
 import { defineRoute } from "$fresh/server.ts";
 import type { TableProps } from "netzo/components/blocks/table/use-table.ts";
-import { I18N, type Invoice } from "@/resources/invoices.ts";
+import { I18N, type Invoice } from "@/data/invoices.ts";
 import { Table } from "@/islands/invoices/Table.tsx";
 import { netzo } from "@/netzo.ts";
 

--- a/templates/crm/routes/transactions/[id].tsx
+++ b/templates/crm/routes/transactions/[id].tsx
@@ -1,6 +1,6 @@
 import { defineRoute } from "$fresh/server.ts";
 import { Separator } from "netzo/components/separator.tsx";
-import type { Transaction } from "@/resources/transactions.ts";
+import type { Transaction } from "@/data/transactions.ts";
 import { FormTransaction } from "@/islands/transactions/Form.tsx";
 import { netzo } from "@/netzo.ts";
 

--- a/templates/crm/routes/transactions/index.tsx
+++ b/templates/crm/routes/transactions/index.tsx
@@ -4,7 +4,7 @@ import {
   I18N,
   type Transaction,
   transactionSchema,
-} from "@/resources/transactions.ts";
+} from "@/data/transactions.ts";
 import { Table } from "@/islands/transactions/Table.tsx";
 import { FormTransaction } from "@/islands/transactions/Form.tsx";
 import { netzo } from "@/netzo.ts";

--- a/templates/crm/tasks/db-mock.ts
+++ b/templates/crm/tasks/db-mock.ts
@@ -17,7 +17,7 @@ export const dbMock = async () => {
   try {
     await Promise.all(
       RESOURCES.map(async (resource) => {
-        const { mock } = await import(`@/resources/${resource}.ts`);
+        const { mock } = await import(`@/data/${resource}.ts`);
         // generate mock data
         const entries = Array.from(Array(length)).map(() => {
           const value = mock();


### PR DESCRIPTION
Improvements from https://github.com/netzo/netzo/pull/125 (hotfix for https://github.com/netzo/netzo/issues/124)

Splits the `resources/{name}.ts` file to `data/{name}.ts` and `routes/api/{name}.ts` to avoid `Deno` from leaking into client.