### PR TITLE
fix(components): re-export layout components from `@/islands/mod.ts`

### DIFF
--- a/lib/plugins/components/plugin.ts
+++ b/lib/plugins/components/plugin.ts
@@ -42,14 +42,13 @@ export const components = (options?: ComponentsConfig): Plugin => {
     csr = true,
   } = options ?? {} as ComponentsConfig;
 
+  const {
+    name: _,
+    ...unocssPlugin
+  } = unocss({ options: { color, radius }, config, aot, ssr, csr });
+
   return {
-    ...unocss({ options: { color, radius }, config, aot, ssr, csr }), // { name, entrypoints, renderAsync, buildStart }
     name: "components",
-    islands: {
-      baseLocation: import.meta.url,
-      paths: [
-        "../../components/layout/mod.ts",
-      ],
-    },
+    ...unocssPlugin,
   };
 };

--- a/templates/crm/fresh.gen.ts
+++ b/templates/crm/fresh.gen.ts
@@ -34,6 +34,7 @@ import * as $interactions_Form from "./islands/interactions/Form.tsx";
 import * as $interactions_Table from "./islands/interactions/Table.tsx";
 import * as $invoices_Form from "./islands/invoices/Form.tsx";
 import * as $invoices_Table from "./islands/invoices/Table.tsx";
+import * as $mod from "./islands/mod.ts";
 import * as $transactions_Form from "./islands/transactions/Form.tsx";
 import * as $transactions_Table from "./islands/transactions/Table.tsx";
 import { type Manifest } from "$fresh/server.ts";
@@ -74,6 +75,7 @@ const manifest = {
     "./islands/interactions/Table.tsx": $interactions_Table,
     "./islands/invoices/Form.tsx": $invoices_Form,
     "./islands/invoices/Table.tsx": $invoices_Table,
+    "./islands/mod.ts": $mod,
     "./islands/transactions/Form.tsx": $transactions_Form,
     "./islands/transactions/Table.tsx": $transactions_Table,
   },

--- a/templates/crm/islands/mod.ts
+++ b/templates/crm/islands/mod.ts
@@ -1,0 +1,2 @@
+// NOTE: re-export specific components from islands/ for reactivity
+export * from "netzo/components/layout/mod.ts";

--- a/templates/crm/routes/_app.tsx
+++ b/templates/crm/routes/_app.tsx
@@ -3,14 +3,14 @@ import { Partial } from "$fresh/runtime.ts";
 import type { NetzoState } from "netzo/mod.ts";
 import { useNetzoState } from "netzo/hooks/server/use-netzo-state.ts";
 import { cn } from "netzo/components/utils.ts";
-import * as Layout from "netzo/components/layout/mod.ts";
+import * as Layout from "../islands/mod.ts";
 
 export default defineApp<NetzoState>((req, ctx) => {
   const { sessionId, sessionUser, mustAuth } = useNetzoState(ctx);
 
   const UI = {
     head: {
-      title: "Company CRM | Netzo",
+      title: "Company CRM",
       description: "A starter template for a custom CRM app",
       favicon: "/favicon.svg",
       image: "/cover.svg",


### PR DESCRIPTION
fix(components): re-export layout components from `@/islands/mod.ts` instead of registering them in `plugins/components` (required for reactivity).

This should fix an issue where an `_app.tsx` file was required due to `plugins/components` registering islands independently of if they were used or not.