### PR TITLE
fix(plugins/unocss): should fix deployment issues due to failing resolution for `unocss` plugin imports

### DIFF
--- a/templates/minimal/netzo.config.ts
+++ b/templates/minimal/netzo.config.ts
@@ -4,5 +4,5 @@ import { unocss } from "netzo/plugins/unocss/plugin.ts";
 export default defineConfig({
   plugins: [
     unocss(),
-  ]
+  ],
 });

--- a/tests/fixture-plugins-unocss/main.ts
+++ b/tests/fixture-plugins-unocss/main.ts
@@ -3,6 +3,7 @@
 /// <reference lib="dom.iterable" />
 /// <reference lib="dom.asynciterable" />
 /// <reference lib="deno.ns" />
+/// <reference lib="deno.unstable" />
 
 import { start } from "$fresh/server.ts";
 import config from "./fresh.config.ts";


### PR DESCRIPTION
Subhosting somehow fails when operating with and/or importing from `file://` URLs. For instance, deploying the following one-file project

```ts
// main.ts
const contents = await Deno.readTextFile("<FILE_URL>");
Deno.serve(() => new Response(contents));
```
fails/works for the following values in place of `<FILE_URL>` after running `netzo deploy`:

❌ `file:///src/main.ts`
❌ `file:///src/main.ts`
✅ `/src/main.ts`
✅ `main.ts`

causing the `unocss` plugin to also fail due to the same reasons. This PR  removes the `file://` prefix from unocss's `configURL` and should fix deployment errors.