### PR TITLE
fix(plugins/unocss): replace dynamic URL import with base64-encoded ES module

### DIFF
--- a/lib/plugins/unocss/plugin.ts
+++ b/lib/plugins/unocss/plugin.ts
@@ -198,7 +198,7 @@ export const unocss = (
       // Load config from file if not passed directly to plugin
       if (config === undefined) {
         try {
-          config = (await import(configURL)).default;
+          config = (await import(configESM)).default;
         } catch (error) {
           if (configFileExists) {
             throw error;


### PR DESCRIPTION
It appears that Subhosting is doing funny things for static-analyzable dynamic imports which might be causing the dynamic import of the `uno.config.ts` file to break deployments, since it works locally. This PR updates the `unocss` plugin to load the `uno.config.ts` from its base64-encoded ES module (like it already does for the client-side CSR script), instead of importing it from a fileURL. This because the file URL is somehow being resolved to `"https://deno.land/home/mrk/playground/crm/uno.config.ts"`, thus throwing the following error

```
error: Uncaught (in promise) TypeError: Module not found "https://deno.land/home/mrk/playground/crm/uno.config.ts".
          config = (await import(configURL)).default;
                    ^
    at async Object.configResolved (https://deno.land/x/netzo@0.4.47/plugins/unocss/plugin.ts:201:21)
    at async Promise.all (index 3)
    at async getServerContext (https://deno.land/x/fresh@1.6.5/src/server/context.ts:77:5)
    at async dev (https://deno.land/x/fresh@1.6.5/src/dev/dev_command.ts:57:17)
    at async file:///home/mrk/playground/crm/dev.ts:6:1
```